### PR TITLE
Deal with user comments containing '='

### DIFF
--- a/lib/flac_parser.ex
+++ b/lib/flac_parser.ex
@@ -160,7 +160,7 @@ defmodule FlacParser do
       data           :: binary
     >> = binary
 
-    [key, value] = String.split(user_comment, "=")
+    [key, value] = String.split(user_comment, "=", parts: 2)
     comments = [[key, value] | comments]
 
     if length(comments) == total_comments do


### PR DESCRIPTION
Parsing a FLAC file with the title `Wooden Toy (Kwes./[o=o]. Rework)`, I was getting:

```
** (MatchError) no match of right hand side value: ["TITLE", "Wooden Toy (Kwes./[o", "o]. Rework)"]
    (flac_parser 0.1.0) lib/flac_parser.ex:163: FlacParser.parse_user_comments/3
    (flac_parser 0.1.0) lib/flac_parser.ex:98: FlacParser.parse_block/2
    (flac_parser 0.1.0) lib/flac_parser.ex:52: FlacParser.parse_block/3
    (flac_parser 0.1.0) lib/flac_parser.ex:23: FlacParser.parse/1
```